### PR TITLE
fix book.toml => book.typ typo

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -116,7 +116,7 @@ pub struct CompileArgs {
 
     /// Output to directory, default in the same directory as the entry file.
     /// Relative paths are interpreted relative to the book's root directory.
-    /// If omitted, shiroa uses build.build-dir from book.toml or defaults
+    /// If omitted, shiroa uses #build-meta.build-dir from book.typ or defaults
     /// to `./dist`.
     #[clap(long, short, default_value = "")]
     pub dest_dir: String,


### PR DESCRIPTION
Found at [myriad-dreamin.github.io/shiroa/cli/build.html#label-–dest-dir](https://myriad-dreamin.github.io/shiroa/cli/build.html#label-%E2%80%93dest-dir,%20-d)